### PR TITLE
Fixes for CentOS/EL7

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,7 @@ In the above setup, the type is os. And this configuration is for the "linux" os
 You can find here some more information about the ossec shared agent configuration: http://ossec-docs.readthedocs.org/en/latest/manual/syscheck/
 
 #### <_role_>/vars/main.yml
-In the vars file, there is the following parameter:
-`ossec_release_rpm`: This is the name of the ossec-release rpm file (Default: ossec-release-1.0-2.el6.art.noarch.rpm)
+nil
 
 Dependencies
 ------------

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -22,7 +22,7 @@
   - { file: 'ossec',
       name: 'CentOS / Red Hat Enterprise Linux $releasever - ossec.net',
       dest: '/etc/yum.repos.d/ossec.repo',
-      mirrorlist: "http://updates.atomicorp.com/channels/mirrorlist/ossec/centos-6-$basearch",
+      mirrorlist: "http://updates.atomicorp.com/channels/mirrorlist/ossec/centos-{{ ansible_distribution_major_version }}-$basearch",
       enabled: 1,
       priority: 1,
       gpgcheck: 1,

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -34,7 +34,6 @@
   with_items:
     - ossec-hids
     - ossec-hids-server
-    - ossec-rules
   tags:
     - init
 

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -6,23 +6,8 @@
     ansible_distribution: centos
   when: ansible_distribution == "RedHat"
 
-- name: RedHat | Install atomicorp repo file
-  template: src=etc-yum.repos.d-rhel.repo.j2
-            dest={{ item.dest }}
-            owner=root
-            group=root
-            mode=0644
-  with_items:
-  - { file: 'ossec',
-      name: 'CentOS / Red Hat Enterprise Linux $releasever - ossec.net',
-      dest: '/etc/yum.repos.d/ossec.repo',
-      mirrorlist: "http://updates.atomicorp.com/channels/mirrorlist/ossec/centos-{{ ansible_distribution_major_version }}-$basearch",
-      enabled: 1,
-      priority: 1,
-      gpgcheck: 1,
-      gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY.ossec.txt' }
-  tags:
-    - init
+- name: RedHat | Install atomicorp repo
+  yum: name=https://www.atomicorp.com/channels/atomic/centos/{{ansible_distribution_major_version}}/x86_64/RPMS/atomic-release-1.0-19.el{{ansible_distribution_major_version}}.art.noarch.rpm state=present
 
 - name: RedHat | Install epel repo
   yum: name=https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ansible_distribution_major_version}}.noarch.rpm state=present

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -24,23 +24,9 @@
   tags:
     - init
 
-- name: RedHat | Install epel repo file
-  template: src=etc-yum.repos.d-rhel.repo.j2
-            dest={{ item.dest }}
-            owner=root
-            group=root
-            mode=0644
-  with_items:
-  - { file: 'epel',
-      name: 'epel',
-      dest: '/etc/yum.repos.d/epel.repo',
-      url: "http://mirror.i3d.net/pub/fedora-epel/$releasever/$basearch/",
-      priority: 2,
-      enabled: 1,
-      gpgcheck: 1,
-      gpgkey: "http://mirror.i3d.net/pub/fedora-epel/RPM-GPG-KEY-EPEL-6" }
-  tags:
-    - init
+- name: RedHat | Install epel repo
+  yum: name=https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ansible_distribution_major_version}}.noarch.rpm state=present
+
 
 - name: RedHat | Install ossec-hids-server
   yum: pkg={{ item }}

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -6,12 +6,6 @@
     ansible_distribution: centos
   when: ansible_distribution == "RedHat"
 
-- name: RedHat | Install release RPM
-  yum: name=https://www.atomicorp.com/channels/ossec/{{ ansible_distribution|lower }}/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/RPMS/{{ ossec_release_rpm }}
-       state=present
-  tags:
-    - init
-
 - name: RedHat | Install atomicorp repo file
   template: src=etc-yum.repos.d-rhel.repo.j2
             dest={{ item.dest }}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,4 +1,3 @@
 ---
 # vars file for ossec-server
 
-ossec_release_rpm: ossec-release-1.0-2.el6.art.noarch.rpm


### PR DESCRIPTION
Supposed to address the following
- Problems with outdated RPM names
- Remove hardcoded mirrors/repo files, use RPM installers for those repos instead (maybe md5/sha summing should be added)
