### PR TITLE
Updates

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -79,6 +79,11 @@
     ossec_init_name: ossec
   when: ansible_os_family == "Debian"
 
+- name: Enable ossec client-syslog if syslog_output is enabled in configuration
+  command: /var/ossec/bin/ossec-control enable client-syslog
+  notify: restart ossec-server
+  when: ossec_server_config.syslog_outputs is defined
+
 - name: Configure the ossec-server
   template: src=var-ossec-etc-ossec-server.conf.j2
             dest=/var/ossec/etc/{{ ossec_server_config_filename }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -73,6 +73,22 @@
     ossec_init_name: ossec-hids
   when: ansible_os_family == "RedHat"
 
+- name: Check if client-syslog is enabled
+  shell: "/var/ossec/bin/ossec-control status | grep -c 'ossec-csyslogd is running' | xargs echo"
+  register: csyslog_running
+  changed_when: False
+
+- name: Check csyslog_running output
+  debug: msg="csyslog running? '{{ csyslog_running.stdout }}'"
+
+- name: Enable client-syslog if not running and ossec_server_config.syslog_outputs is given
+  command: /var/ossec/bin/ossec-control enable client-syslog
+  when: csyslog_running.stdout == '0' and ossec_server_config.syslog_outputs is defined
+
+- name: Start client-syslog if not running and ossec_server_config.syslog_outputs is given
+  command: /var/ossec/bin/ossec-control start client-syslog
+  when: csyslog_running.stdout == '0' and ossec_server_config.syslog_outputs is defined
+
 - name: Set ossec deploy facts for Debian
   set_fact:
     ossec_server_config_filename: ossec.conf

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -78,9 +78,6 @@
   register: csyslog_running
   changed_when: False
 
-- name: Check csyslog_running output
-  debug: msg="csyslog running? '{{ csyslog_running.stdout }}'"
-
 - name: Enable client-syslog if not running and ossec_server_config.syslog_outputs is given
   command: /var/ossec/bin/ossec-control enable client-syslog
   when: csyslog_running.stdout == '0' and ossec_server_config.syslog_outputs is defined
@@ -94,11 +91,6 @@
     ossec_server_config_filename: ossec.conf
     ossec_init_name: ossec
   when: ansible_os_family == "Debian"
-
-- name: Enable ossec client-syslog if syslog_output is enabled in configuration
-  command: /var/ossec/bin/ossec-control enable client-syslog
-  notify: restart ossec-server
-  when: ossec_server_config.syslog_outputs is defined
 
 - name: Configure the ossec-server
   template: src=var-ossec-etc-ossec-server.conf.j2

--- a/templates/var-ossec-etc-ossec-server.conf.j2
+++ b/templates/var-ossec-etc-ossec-server.conf.j2
@@ -4,8 +4,8 @@
   <global>
     {% if ossec_server_config.email_notification is not defined or ossec_server_config.email_notification | lower == "yes" %}
     <email_notification>yes</email_notification>
-{% for ossec_server_config in ossec_server_config.mail_to %}
-    <email_to>{{ ossec_server_config }}</email_to>
+{% for to in ossec_server_config.mail_to %}
+    <email_to>{{ to }}</email_to>
 {% endfor %}
     <smtp_server>{{ ossec_server_config.mail_smtp_server }}</smtp_server>
     <email_from>{{ ossec_server_config.mail_from }}</email_from>
@@ -13,6 +13,35 @@
     <email_notification>no</email_notification>
     {% endif %}
   </global>
+
+{% if ossec_server_config.extra_emails is defined %}
+{% for mail in ossec_server_config.extra_emails %}
+  <email_alerts>
+    <email_to>{{ mail.mail_to }}</email_to>
+    {% if mail.format is defined %}
+    <format>{{ mail.format }}</format>
+    {% endif %}
+    {% if mail.level is defined %}
+    <level>{{ mail.level }}</level>
+    {% endif %}
+    {% if mail.event_location is defined %}
+    <event_location>{{ mail.event_location }}</event_location>
+    {% endif %}
+    {% if mail.group is defined %}
+    <group>{{ mail.group }}</group>
+    {% endif %}
+    {% if mail.do_not_delay is defined and mail.do_not_delay == true %}
+    <do_not_delay />
+    {% endif %}
+    {% if mail.do_not_group is defined and mail.do_not_group == true %}
+    <do_not_group />
+    {% endif %}
+    {% if mail.rule_id is defined %}
+    <rule_id>{{ mail.rule_id }}</rule_id>
+    {% endif %}
+  </email_alerts>
+{% endfor %}    
+{% endif %}
 
   <rules>
     <include>rules_config.xml</include>

--- a/templates/var-ossec-etc-ossec-server.conf.j2
+++ b/templates/var-ossec-etc-ossec-server.conf.j2
@@ -141,7 +141,7 @@
   </localfile>
 {% endfor %}
 
-{% if syslog_output is defined %}
+{% if ossec_server_config.syslog_outputs is defined %}
 {% for syslog_output in ossec_server_config.syslog_outputs %}
   <syslog_output>
     <server>{{ syslog_output.server }}</server>


### PR DESCRIPTION
My last pull request contained a bug with the added syslog_outputs config section.

Added settings for granular emails in ossec.conf. See http://ossec-docs.readthedocs.org/en/latest/syntax/head_ossec_config.email_alerts.html
