### PR TITLE
refactor cis_distribution_filename usage to be more dry

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -9,16 +9,11 @@
   apt: pkg=ossec-hids
        state=present
 
-- name: Install Debian CIS Root Checks
-  get_url:
-    url: https://raw.githubusercontent.com/ossec/ossec-hids/master/src/rootcheck/db/cis_debian_linux_rcl.txt
-    dest: /var/ossec/etc/shared/cis_rhel6_linux_rcl.txt
-    mode: 0660
-    owner: root
-    group: ossec
-
-
 - name: Set Distribution CIS filename for Debian/Ubuntu
   set_fact:
     cis_distribution_filename: cis_debian_linux_rcl.txt
-  when: ansible_os_family == "Debian"
+
+- name: Set ossec deploy facts for Debian
+  set_fact:
+    ossec_server_config_filename: ossec.conf
+    ossec_init_name: ossec

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -12,7 +12,6 @@
 - name: RedHat | Install epel repo
   yum: name=https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ansible_distribution_major_version}}.noarch.rpm state=present
 
-
 - name: RedHat | Install ossec-hids-server
   yum: pkg={{ item }}
        state=present
@@ -22,39 +21,22 @@
   tags:
     - init
 
-- name: Install RHEL6 CIS Root Checks
-  get_url:
-    url: https://raw.githubusercontent.com/ossec/ossec-hids/master/src/rootcheck/db/cis_rhel6_linux_rcl.txt
-    dest: /var/ossec/etc/shared/cis_rhel6_linux_rcl.txt
-    mode: 0660
-    owner: root
-    group: ossec
-
-- name: Install RHEL7 CIS Root Checks
-  get_url:
-    url: https://raw.githubusercontent.com/ossec/ossec-hids/master/src/rootcheck/db/cis_rhel7_linux_rcl.txt
-    dest: /var/ossec/etc/shared/cis_rhel7_linux_rcl.txt
-    mode: 0660
-    owner: root
-    group: ossec
-
 - name: Set Distribution CIS filename for RHEL5
   set_fact:
     cis_distribution_filename: cis_rhel5_linux_rcl.txt
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "5"
+  when: ansible_distribution_major_version == "5"
 
 - name: Set Distribution CIS filename for RHEL6
   set_fact:
     cis_distribution_filename: cis_rhel6_linux_rcl.txt
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "6"
+  when: ansible_distribution_major_version == "6"
 
 - name: Set Distribution CIS filename for RHEL7
   set_fact:
     cis_distribution_filename: cis_rhel7_linux_rcl.txt
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "7"
+  when: ansible_distribution_major_version == "7"
 
 - name: Set ossec deploy facts for RedHat
   set_fact:
     ossec_server_config_filename: ossec-server.conf
     ossec_init_name: ossec-hids
-  when: ansible_os_family == "RedHat"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,13 @@
   include: "Debian.yml"
   when: ansible_os_family == "Debian"
 
+- name: Install CIS Root Checks
+  get_url:
+    url: "https://raw.githubusercontent.com/ossec/ossec-hids/master/src/rootcheck/db/{{ cis_distribution_filename }}"
+    dest: "/var/ossec/etc/shared/{{ cis_distribution_filename }}"
+    mode: 0660
+    owner: root
+    group: ossec
 
 - name: Generate SSL files
   command: "openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:1825 -keyout sslmanager.key -out sslmanager.cert -subj /CN={{ossec_server_fqdn}}/"
@@ -79,12 +86,6 @@
 - name: Start client-syslog if not running and ossec_server_config.syslog_outputs is given
   command: /var/ossec/bin/ossec-control start client-syslog
   when: csyslog_running.stdout == '0' and ossec_server_config.syslog_outputs is defined
-
-- name: Set ossec deploy facts for Debian
-  set_fact:
-    ossec_server_config_filename: ossec.conf
-    ossec_init_name: ossec
-  when: ansible_os_family == "Debian"
 
 - name: Configure the ossec-server
   template: src=var-ossec-etc-ossec-server.conf.j2


### PR DESCRIPTION
at the same time fixing an error on the Debian side where cis_debian_linux_rcl.txt was saved to cis_rhel6_linux_rcl.txt

I removed a lot of the `ansible_os_family` checks as they are inside a file that only runs after that same `ansible_os_family` check