### PR TITLE
Fix check-mode with syslog-output configured

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -101,6 +101,7 @@
   shell: "/var/ossec/bin/ossec-control status | grep -c 'ossec-csyslogd is running' | xargs echo"
   register: csyslog_running
   changed_when: False
+  check_mode: False
   when:
     - ossec_server_config.syslog_outputs is defined
 


### PR DESCRIPTION
Allow ossec-server role to be run in check-mode when configuring syslog-output

Bugfix Pull Request