### PR TITLE
Update to current ansible/molecule/testinfra and fix CentOS7 init.

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,9 +2,10 @@
 # handlers file for ossec-server
 
 - name: restart ossec-server
-  service: name={{ ossec_init_name }}
-           state=restarted
-           enabled=yes
+  service:
+    name: "{{ ossec_init_name }}"
+    state: restarted
+    enabled: yes
 
 - name: systemd daemon-reload
   command: systemctl daemon-reload

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -2,8 +2,3 @@
 - hosts: all
   roles:
     - role: ansible-ossec-server
-  post_tasks:
-    - name: "Starting auth daemon"
-      service:
-        name: ossec-authd
-        state: started

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -2,19 +2,17 @@
 - name: Prepare
   hosts: all
   tasks:
-    - name: "Installing which on CentOS"
+    - name: "Installing tools on CentOS"
       yum:
-        name: "{{ item }}"
-        state: installed
-      with_items:
-        - net-tools
-        - which
+        pkg:
+          - net-tools
+          - which
+        state: present
       when: ansible_distribution == 'CentOS'
 
-    - name: "Installing which on NON-CentOS"
+    - name: "Installing tools on NON-CentOS"
       apt:
-        name: "{{ item }}"
-        state: installed
-      with_items:
-        - net-tools
+        name:
+          - net-tools
+        state: present
       when: ansible_distribution != 'CentOS'

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -1,14 +1,8 @@
-import os
 import pytest
 
-import testinfra.utils.ansible_runner
 
-testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
-
-
-def test_ossec_package_installed(Package):
-    ossec = Package('ossec-hids')
+def test_ossec_package_installed(host):
+    ossec = host.package('ossec-hids')
     assert ossec.is_installed
 
 
@@ -38,18 +32,17 @@ def test_ossec_verify_agent_conf(host):
     assert cmd.rc == 0
 
 
-def test_sockets_open(Socket, SystemInfo):
-    if SystemInfo.distribution == 'debian':
-        assert Socket("tcp://0.0.0.0:1515").is_listening
-    elif SystemInfo.distribution == 'centos':
-        assert Socket("tcp://:::1515").is_listening
+def test_sockets_open(host):
+    if host.system_info.distribution == 'debian':
+        assert host.socket("tcp://0.0.0.0:1515").is_listening
+    elif host.system_info.distribution == 'centos':
+        assert host.socket("tcp://:::1515").is_listening
 
 
-def test_ossec_configuration(File):
-    ossec = File("/var/ossec/etc/ossec.conf")
+def test_ossec_configuration(host):
+    ossec = host.file("/var/ossec/etc/ossec.conf")
     assert ossec.user == "root"
     assert ossec.group == "root"
-
     assert ossec.contains("<email_to>me@example.com</email_to>")
     assert ossec.contains("<ignore>/etc/hosts.deny</ignore>")
     assert ossec.contains("<white_list>127.0.0.1</white_list>")

--- a/molecule/default/yaml-lint.yml
+++ b/molecule/default/yaml-lint.yml
@@ -4,6 +4,6 @@ extends: default
 
 rules:
   line-length:
-    max: 120
+    max: 220
     level: warning
   truthy: disable

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible==2.4.4.0
-docker==3.3.0
-molecule==2.13.1
-testinfra==1.12.0
+ansible==2.7.5
+docker==3.6.0
+molecule==2.19.0
+testinfra==1.16.0

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -22,5 +22,6 @@
       set_fact:
         ossec_server_config_filename: ossec.conf
         ossec_init_name: ossec
+        ossec_authd_init_name: ossec-authd
   tags:
     - always

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -3,7 +3,7 @@
 
 - name: "RedHat | Set some facts"
   set_fact:
-    ansible_distribution: centos
+    ansible_distribution: CentOS
   when: ansible_distribution == "RedHat"
   tags:
     - always
@@ -20,11 +20,10 @@
 
 - name: "RedHat | Install ossec-hids-server"
   yum:
-    pkg: "{{ item }}"
+    pkg:
+      - ossec-hids
+      - ossec-hids-server
     state: present
-  with_items:
-    - ossec-hids
-    - ossec-hids-server
   tags:
     - init
 
@@ -48,5 +47,6 @@
       set_fact:
         ossec_server_config_filename: ossec-server.conf
         ossec_init_name: ossec-hids
+        ossec_authd_init_name: ossec-hids-authd
   tags:
     - always

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -138,13 +138,23 @@
   when:
     - ansible_service_mgr == "systemd"
     - ansible_os_family != "CoreOS"
+    - ansible_os_family != "RedHat"
   notify: systemd daemon-reload
   tags:
     - init
     - config
 
+- name: "Remove pidfile line from startup script (breaks systemd controlled rc script)"
+  lineinfile:
+    dest: /etc/rc.d/init.d/ossec-hids-authd
+    regex: '^# pidfile:'
+    state: absent
+  when:
+    - ansible_service_mgr == "systemd"
+    - ansible_os_family == "RedHat"
+
 - name: "Ensure ossec authd service is started and enabled"
   service:
-    name: ossec-authd
+    name: "{{ ossec_authd_init_name }}"
     enabled: yes
     state: started


### PR DESCRIPTION
**Description of PR**
See individual commit messages

**Type of change**
Bugfix Pull Request

**Fixes an issue**
Fixes CentOS7 including init script in RPM vs role dropping systemd unit.
Fixes molecule tests not working with latest versions of testinfra
Corrects style for Ansible 2.7

