### PR TITLE
Change SSL key size to 3072 bits

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,7 +27,7 @@
     group: ossec
 
 - name: "Generate SSL files"
-  command: "openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:1825 -keyout sslmanager.key -out sslmanager.cert -subj /CN={{ ossec_server_fqdn }}/"
+  command: "openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:3072 -keyout sslmanager.key -out sslmanager.cert -subj /CN={{ ossec_server_fqdn }}/"
   args:
     creates: sslmanager.cert
     chdir: /var/ossec/etc/


### PR DESCRIPTION
**Description of PR**

Changes the generated cert size from 1825->3072 bits, following [OpenSSL's default](https://www.openssh.com/txt/release-8.0). In particular, the default breaks on at least OpenSSL 1.1.1f, while a keysize of 3072 bits works fine:

```
jeff@ip-10-0-1-69:~$ sudo /var/ossec/bin/ossec-authd -fdd -p 1515
2021/10/05 17:45:13 ossec-authd: DEBUG: Starting ...
2021/10/05 17:45:13 ossec-authd: INFO: Started (pid: 67944).
2021/10/05 17:45:13 Accepting connections. Using password specified on file: /var/ossec/etc/authd.pass
2021/10/05 17:45:13 ossec-authd: ERROR: Unable to read certificate file: /var/ossec/etc/sslmanager.cert
140369872856896:error:140AB18F:SSL routines:SSL_CTX_use_certificate:ee key too small:../ssl/ssl_rsa.c:310:
2021/10/05 17:45:13 ossec-authd: ERROR: SSL error. Exiting.
```

**Type of change**

Bugfix Pull Request
